### PR TITLE
got parcel stats writing to json file. fixed entry such that ia src/i…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ jspm_packages
 
 .vs/
 .vscode/
+.cache/

--- a/app/src/components/Main.jsx
+++ b/app/src/components/Main.jsx
@@ -78,6 +78,7 @@ export class Main extends Component {
     });
 
     ipcRenderer.on('webpack-stats-results-json', event => {
+      ipcRenderer.send('run-parcel');
       this.props.retrieveCompilationStats();
     });
 

--- a/backend/create-config/utils/createWebPackConfigHelpers/createConfigStringFromParams.js
+++ b/backend/create-config/utils/createWebPackConfigHelpers/createConfigStringFromParams.js
@@ -22,7 +22,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
-    entry: ${entry},
+    entry: '${entry}',
     context: '${rootDir}',
     output: {
       path: '${output}',

--- a/backend/create-config/utils/createWebPackConfigHelpers/getInfoForWebpackConfigFromFileList.js
+++ b/backend/create-config/utils/createWebPackConfigHelpers/getInfoForWebpackConfigFromFileList.js
@@ -34,7 +34,7 @@ module.exports = files => {
     }
     // make sure /src/ is in the root of the project (name should be src/index.js when you remove src/index.js)
     if (fullPath.includes('/src/index.js') && fullPath.replace('/src/index.js', '') === rootDir) {
-      entry = `'${fullPath}'`;
+      entry = fullPath;
     }
     return files.concat(name);
   }, []);

--- a/backend/create-config/utils/createWebPackConfigHelpers/parseEntryFromWebpack.js
+++ b/backend/create-config/utils/createWebPackConfigHelpers/parseEntryFromWebpack.js
@@ -16,15 +16,17 @@ module.exports = (res, { content }) => {
               .trim();
             let entryValuePlusRootDir = path.join(res.rootDir, entryValueInWebpackConfig);
             if (fs.existsSync(entryValueInWebpackConfig)) {
-              entry = `'${entryValueInWebpackConfig}'`;
+              entry = entryValueInWebpackConfig;
             } else if (fs.existsSync(entryValuePlusRootDir)) {
-              entry = `'${entryValuePlusRootDir}'`;
+              entry = entryValuePlusRootDir;
             }
           }
         },
       },
     });
-    res.entry = entry;
+    if (entry) {
+      res.entry = entry;
+    }
     return res;
   } catch (error) {
     return res;

--- a/backend/create-config/utils/runParcel.js
+++ b/backend/create-config/utils/runParcel.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const { exec } = require('child_process');
+const getSavedProjectDataFromFile = require('./createWebPackConfigHelpers/getSavedProjectDataFromFile.js');
+
+const pathToWriteStatsFile = process.argv[process.argv.length - 1];
+const pathToSavedData = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'electronUserData',
+  'configurationData.js'
+);
+getSavedProjectDataFromFile(pathToSavedData)
+  .then(({ entry, indexHtmlPath, rootDir }) => {
+    const parcelEntryFile = indexHtmlPath || entry;
+    exec(
+      `parcel build ${parcelEntryFile} --detailed-report > ${pathToWriteStatsFile}`,
+      null,
+      error => {
+        if (error) process.send({ error });
+        else process.send({ status: 'done' });
+        process.exit();
+      }
+    );
+  })
+  .catch(e => console.log(e));

--- a/backend/create-config/utils/runWebpack.js
+++ b/backend/create-config/utils/runWebpack.js
@@ -7,6 +7,7 @@ const statsWritePath = process.argv[process.argv.length - 1];
 exec(`webpack --profile --json > ${statsWritePath}`, null, error => {
   if (error) process.send({ error });
   else process.send({ status: 'done' });
+  process.exit();
 });
 
 // exec(`webpack --profile --json`, { maxBuffer: 1024 * 100000 }, (error, stdout) => {

--- a/main_process.js
+++ b/main_process.js
@@ -94,3 +94,20 @@ ipcMain.on('run-webpack', (event, { createNewConfig, pathFromDrag }) => {
     });
   }
 });
+// gets called like 6 times. not sure why
+let stopParcelRunningAgain = false;
+ipcMain.on('run-parcel', event => {
+  if (!stopParcelRunningAgain) {
+    stopParcelRunningAgain = true;
+    const pathToRunParcelFileModule = path.join(
+      __dirname,
+      'backend',
+      'create-config',
+      'utils',
+      'runParcel.js'
+    );
+    const pathToWriteStatsFile = path.join(__dirname, 'electronUserData', 'parcel-stats.json');
+    const createParcelChild = fork(pathToRunParcelFileModule, [pathToWriteStatsFile]);
+    createParc
+  }
+});


### PR DESCRIPTION
…ndex.js didnt get overwritten by an empty entrypoint in webpack.config when parsing webpack config to add an entry to our generated config. also, changed all the entry items such that they are sent through without the single quotes, and then i just add that a single time in the config file around the template string injected entry variable.